### PR TITLE
Update vipers-video-quicktags.php

### DIFF
--- a/vipers-video-quicktags.php
+++ b/vipers-video-quicktags.php
@@ -3067,7 +3067,7 @@ class VipersVideoQuicktags {
 		$byline     = ( 1 == $atts['byline'] )     ? '1' : '0';
 		$fullscreen = ( 1 == $atts['fullscreen'] ) ? '1' : '0';
 
-		$iframeurl = 'http://player.vimeo.com/video/' . $videoid;
+		$iframeurl = '//player.vimeo.com/video/' . $videoid;
 		foreach ( array( 'title', 'byline', 'portrait', 'fullscreen' ) as $attribute ) {
 			$iframeurl = add_query_arg( $attribute, $$attribute, $iframeurl );
 		}


### PR DESCRIPTION
Vimeo videos served on a HTTPS-enabled blog will be blocked in Chrome by default:

> The page was loaded over HTTPS, but ran insecure content…this content should also be loaded over HTTPS.

Hence I've change this to use a [schemeless URL](http://www.paulirish.com/2010/the-protocol-relative-url/)
